### PR TITLE
Fix post merge nov22

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -1,7 +1,7 @@
 // Const declaration
 export const GRID_WIDTH: number = 20;
 export const GRID_HEIGHT: number = 20;
-export const GRID_SIZE: number = 12;
+export const GRID_SIZE: number = 3;
 
 export const DIRECTIONS: string[] = [
   'horizontal',
@@ -37,6 +37,8 @@ export const WORD_LIST: string[] = [
 ];
 
   export const WORD_LIST_TREES: string[] = [
+    "fir"
+    /*
     "arbutus",
     "birch",
     "pine",
@@ -52,6 +54,7 @@ export const WORD_LIST: string[] = [
     "beech",
     "basswood",
     "elm"
+    */
   ]
 
   export const ALPHABET: string = 'abcdefghijklmnoprstuvwy';

--- a/src/app/lauren-grid.service.ts
+++ b/src/app/lauren-grid.service.ts
@@ -61,6 +61,7 @@ export class LaurenGridService implements IBoardGenerator {
 	updateTile(tile: ITile,val: string,word: string): ITile {
 		tile.letter = this.formatLetter(val);
 		tile.words.push(word);
+		tile.isWord = true;
 		return tile;
 	}
 	createTile(rowI: number, colI: number): ITile {
@@ -69,9 +70,10 @@ export class LaurenGridService implements IBoardGenerator {
 			indexColumn: colI,
 			letter: this.getRandomLetter(),
 			isSelected: false,
-			isWord:false,
-			foundCount: 0,
 			words:[],
+			isWord:false,
+			isFound: false,
+			foundCount: 0,
 		}
 		return tile;
 	}
@@ -90,14 +92,10 @@ export class LaurenGridService implements IBoardGenerator {
 		}
 	}
 	getOpenSpots(board: ITile[][], word: string): ILocation[] {
-		const spots = [];
-	 	board.forEach((row,rowI) => {
-		 row.forEach((c,colI)=> {
-			let spot = this.createSpot(rowI,colI,word,board);
-			 if (spot) spots.push(spot);
-		 })
-	 })
-	 return spots;
+	 const grid = [...Array(board.length)]; 
+	 return grid.flatMap((r,row) => grid
+		 .map((c,col) => this.createSpot(row,col,word,board)))
+		 .filter(openSpot => openSpot);
 	}
 	createSpot(rowI: number, colI: number, word: string, board: ITile[][]): ILocation {
 		const direction = this.getRandomDirection(rowI,colI,word,board);
@@ -105,7 +103,7 @@ export class LaurenGridService implements IBoardGenerator {
 			return {
 				indexRow: rowI,
 				indexColumn: colI,
-				direction: direction,
+				direction: direction
 			}
 		}
 	}

--- a/src/app/tile/tile.component.html
+++ b/src/app/tile/tile.component.html
@@ -1,1 +1,2 @@
-<div (click)="isSelectedChange()" [class.word]="tile.isWord" [class.selected]="tile.isSelected" class="tile--content">{{tile?.letter}}</div>
+<div (click)="isSelectedChange()" [class.word]="tile.isFound" [class.selected]="tile.isSelected" 
+class="tile--content"> {{tile?.letter}}</div>

--- a/src/app/tile/tile.component.scss
+++ b/src/app/tile/tile.component.scss
@@ -1,9 +1,12 @@
 .tile--content {
 	align-self: center;
-	text-transform: uppercase;
+//	text-transform: uppercase;
 	font-family: sans-serif;
 	font-size: 2.5rem;
 	text-align: center;
+	&.word {
+		color: red;
+	}
 }
 
 :host:hover {

--- a/src/app/tile/tile.component.ts
+++ b/src/app/tile/tile.component.ts
@@ -21,7 +21,9 @@ export class TileComponent implements OnInit {
 	}
 	
 	isSelectedChange() {
-		this.tile.isSelected = !this.tile.isSelected;
-		this.notifySelection.emit(this.tile);
+		if (!this.tile.isFound) {
+			this.tile.isSelected = !this.tile.isSelected;
+			this.notifySelection.emit(this.tile);
+    }	
 	}
 }

--- a/src/app/word-grid/word-grid.component.html
+++ b/src/app/word-grid/word-grid.component.html
@@ -9,7 +9,6 @@
 	</div>
 </article> -->
 <div  class="grid__row" *ngFor="let row of gameGrid">
-	<app-tile [tile]="tile" (notifySelection)="selectedChanged($event)" class="grid__tile" *ngFor="let tile of row">
-	  <span>{{tile.letter}}</span>
+	<app-tile [tile]="tile" (notifySelection)="selectedChanged(tile)" [class.word]="tile.isWord" class="grid__tile word" *ngFor="let tile of row">
 	</app-tile>
 </div>

--- a/src/app/word-grid/word-grid.component.ts
+++ b/src/app/word-grid/word-grid.component.ts
@@ -18,8 +18,7 @@ export class WordGridComponent implements OnInit {
   ngAfterViewInit() { }
 
   selectedChanged(tile:ITile): void {
-    const isWordTile = tile.words.length > 0;
-    if (isWordTile) {
+    if (tile.isWord) {
       tile.words.forEach((word) => this.checkForFoundWords(word));
     }
   }

--- a/src/app/word-grid/word-grid.models.ts
+++ b/src/app/word-grid/word-grid.models.ts
@@ -8,7 +8,8 @@ export interface ITile {
   indexColumn?: number;
   isSelected?: boolean;
   isWord?: boolean;
-  foundCount?:number;
+  isFound?: boolean;
+  foundCount? :number;
 }
 
 export interface ILocation {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "target": "es2015",
     "module": "es2020",
     "lib": [
-      "es2018",
+      "es2019",
       "dom"
     ]
   }


### PR DESCRIPTION
Swapped es2018 for es2019 in ts config file so we can use array.flat, array.flatMap

Made the tile component toggle its own isSelected property after the click (grid was previously handling it after the event was emitted)

Removed view children from word-grid, now it directly maps the gameGrid data to get selected tiles 

Changed properties on ITile / refactored to account for the changes:
-isWord property indicates a tile belongs to a word 
-isFound property indicates a tile is part of a word that has been found (isWord was doing this job previously).
** isFound does not indicate that every word a tile belongs to has been found



