### PR TITLE
add emitter back  to grid markup, .word class to tile scss

### DIFF
--- a/src/app/tile/tile.component.html
+++ b/src/app/tile/tile.component.html
@@ -1,3 +1,7 @@
-<div class="tile" (click)="isSelectedChange()" [class.word]="tile.isFound" [class.selected]="tile.isSelected" tabindex=0> 
+<div class="tile" 
+  (click)="isSelectedChange()" 
+  [class.word]="tile.isFound" 
+  [class.selected]="tile.isSelected" 
+  tabindex=0> 
   <span class="letter">{{tile?.letter}}</span>
 </div>

--- a/src/app/tile/tile.component.scss
+++ b/src/app/tile/tile.component.scss
@@ -60,3 +60,6 @@
   box-shadow: var(--box-shadow-pressed);
   color: var(--color-primary);
 }
+.word {
+  color: red;
+}

--- a/src/app/word-grid/word-grid.component.html
+++ b/src/app/word-grid/word-grid.component.html
@@ -1,7 +1,12 @@
 <article aria-role="grid" class="grid" aria-label="game board">
 	<div class="grid__row" [style.--grid]="gridSize" aria-role="row" *ngFor="let row of gameGrid; let i = index" [attr.data-index]="i">
-		<div class="grid__item" *ngFor="let tile of row; let j = index" [attr.aria-label]="letter" aria-selected="false" [attr.data-row]="i" [attr.data-index]="j">
-			<app-tile [tile]="tile"></app-tile>
+		<div class="grid__item" 
+			*ngFor="let tile of row; let j = index" 
+			[attr.aria-label]="letter" 
+			aria-selected="false" 
+			[attr.data-row]="i" 
+			[attr.data-index]="j">
+			<app-tile [tile]="tile" (notifySelection)="selectedChanged($event)"></app-tile>
 		</div>
 	</div>
 </article> 


### PR DESCRIPTION
@diegomouradev  : 
Word grid markup was missing  event emitter after css change, added back. 
Found word letters will change to red via the rudimentary .word class in tile scss.